### PR TITLE
Changed Fragment lookups to use class.getName() rather than string literals to prevent Proguard issues

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -581,7 +581,7 @@ public class ArgProcessor extends AbstractProcessor {
       for (Map.Entry<String, String> entry : mapping.entrySet()) {
 
         jw.emitEmptyLine();
-        jw.beginControlFlow("if ( \"%s\".equals(targetName) )", entry.getKey());
+        jw.beginControlFlow("if ( %s.class.getName().equals(targetName) )", entry.getKey());
         jw.emitStatement("%s.injectArguments( ( %s ) target)", entry.getValue(), entry.getKey());
         jw.emitStatement("return");
         jw.endControlFlow();


### PR DESCRIPTION
When Proguard obfuscation is enabled, the injector can't find the Fragment class that's referenced as a string literal. Instead, use class.getName(), which will match the obfuscated Fragment class.