### PR TITLE
Add fragment build time validation of arguments

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -192,6 +192,12 @@ public class ArgProcessor extends AbstractProcessor {
 
     jw.emitEmptyLine();
 
+    if (!arg.isPrimitive()) {
+      jw.beginControlFlow("if (%s == null)", arg.getName());
+      jw.emitStatement("throw new NullPointerException(\"Argument '%s' must not be null.\")", arg.getName());
+      jw.endControlFlow();
+    }
+
     if (arg.hasCustomBundler()) {
       jw.emitStatement("%s.putBoolean(\"%s\", true)", bundleVariable,
           CUSTOM_BUNDLER_BUNDLE_KEY + arg.getKey());


### PR DESCRIPTION
We're looking into replacing all of our [`newInstance`](http://stackoverflow.com/a/9245510/111777) methods with FragmentArgs. A common pattern that we have is calling [`checkNotNull`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/base/Preconditions.html#checkNotNull(T)) when building the arguments Bundle:

```
public static ExampleFragment newInstance(@NonNull String anArgument,
                                          boolean anotherArgument) {
    ExampleFragment f = new ExampleFragment();
    Bundle args = new Bundle(2);
    args.putString(ARGS_AN_ARGUMENT, checkNotNull(anArgument));
    args.putBoolean(ARGS_ANOTHER_ARGUMENT, anotherArgument);
    f.setArguments(args);
    return f;
}
```

This makes sure that we [crash fast](http://www.slideshare.net/pyricau/crash-fast) and ensures that the calling location shows up in the stack trace on our crash reporting. The alternative of checking for null inside of `onCreate` means that the calling location is lost.

What do you think about moving the argument validation from the `injectArguments` method into the `build()` method?

Instead of (or in addition to) this:

```
  public static final void injectArguments(@NonNull ExampleFragment fragment) {
    Bundle args = fragment.getArguments();
    if (args == null) {
      throw new IllegalStateException("No arguments set. Have you setup this Fragment with the corresponding FragmentArgs Builder? ");
    }

    if (!args.containsKey("anotherArgument")) {
      throw new IllegalStateException("required argument anotherArgument is not set");
    }
    fragment.anotherArgument = args.getBoolean("anotherArgument");

    if (!args.containsKey("anArgument")) {
      throw new IllegalStateException("required argument anArgument is not set");
    }
    fragment.anArgument = args.getString("anArgument");
  }
```

you would have this:

```
  @NonNull
  public ExampleFragment build() {
    if (!mArguments.containsKey("anotherArgument")) {
      throw new IllegalStateException("required argument anotherArgument is not set");
    }
   
    if (!mArguments.containsKey("anArgument")) {
      throw new IllegalStateException("required argument blah is not set");
    }
    if (args.getString("anArgument") == null) {
      throw new NullPointerException("argument anArgument may not be null");
    }

    ExampleFragment fragment = new ExampleFragment();
    fragment.setArguments(mArguments);
    return fragment;
  }
```

The validation logic could be extracted to its own method, but I think you see what I'm suggesting. What do you think?
