### PR TITLE
Change order of Parcelable/Serializable in ArgProcessor.getOperation

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -163,12 +163,12 @@ public class ArgProcessor extends AbstractProcessor {
       return "SparseParcelableArray";
     }
 
-    if (types.isAssignable(type, elements.getTypeElement(Serializable.class.getName()).asType())) {
-      return "Serializable";
-    }
-
     if (types.isAssignable(type, elements.getTypeElement("android.os.Parcelable").asType())) {
       return "Parcelable";
+    }
+
+    if (types.isAssignable(type, elements.getTypeElement(Serializable.class.getName()).asType())) {
+      return "Serializable";
     }
 
     return null;


### PR DESCRIPTION
This seems to fix the problem of Serializable being prioritized above Parcelable in issue #64 