### PR TITLE
Tiny correction to README "How to use" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The changelog can be found [here](https://github.com/sockeqwe/fragmentargs/blob/
 FragmentArgs generates Java code at compile time. It generates a `Builder` class out of your Fragment class.
 
  1. Annotate your `Fragment` with `@FragmentWithArgs`.  For backward compatibility reasons this is not mandatory. However it's strongly recommended because in further versions of FragmentArgs this could become mandatory to support more features.
- 2. Annotate your fields with `@Args`. Fields **should** have at least package (default) visibility. Alternatively, you have to provide a setter method with at least package (default) visibility for your private `@Args` annotated fields. 
+ 2. Annotate your fields with `@Arg`. Fields **should** have at least package (default) visibility. Alternatively, you have to provide a setter method with at least package (default) visibility for your private `@Arg` annotated fields. 
  3. In the Fragments `onCreate(Bundle)` method you have to call `FragmentArgs.inject(this)` to read the arguments and set the values. 
  4. Unlike Eclipse Android Studio does not auto compile your project while saving files. So you may have to build your project to start the annotation processor which will generate the `Builder` classes for your annotated fragments.
 


### PR DESCRIPTION
The second step in the "How to use" section says the  annotation `@Args` should be used, but this should (probably) say `@Arg`.