### PR TITLE
Add missing import on Builder generated with optional fields 

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -567,7 +567,7 @@ public class ArgProcessor extends AbstractProcessor {
           superClass = element.getSuperclass();
         }
 
-        String qualifiedFragmentName = fragment.getQualifiedName().toString();
+        String qualifiedFragmentName = fragment.getQualifiedName();
         String qualifiedBuilderName = qualifiedFragmentName + "Builder";
 
         Element[] orig = originating.toArray(new Element[originating.size()]);
@@ -580,7 +580,7 @@ public class ArgProcessor extends AbstractProcessor {
         jw.emitImports("android.os.Bundle");
         if (supportAnnotations) {
           jw.emitImports("android.support.annotation.NonNull");
-          if (!fragment.getRequiredFields().isEmpty()) {
+          if (!fragment.getOptionalFields().isEmpty()) {
             jw.emitImports("android.support.annotation.Nullable");
           }
         }


### PR DESCRIPTION
Because getRequiredFields() was used to determine if android.support.annotation.Nullable needs to be added the generated Builder won't compile.