### PR TITLE
add @NonNull annotation to buildBundle and builderMethods

### DIFF
--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgProcessor.java
@@ -686,6 +686,7 @@ public class ArgProcessor extends AbstractProcessor {
      * @throws IOException
      */
     private void writeBuildBundleMethod(JavaWriter jw) throws IOException {
+        if (supportAnnotations) jw.emitAnnotation("NonNull");
         jw.beginMethod("Bundle", "buildBundle", EnumSet.of(Modifier.PUBLIC));
         jw.emitStatement("return new Bundle(mArguments)");
         jw.endMethod();
@@ -958,6 +959,7 @@ public class ArgProcessor extends AbstractProcessor {
             typeStr = arg.getType();
         }
 
+        if (supportAnnotations) writer.emitAnnotation("NonNull");
         writer.beginMethod(type, arg.getVariableName(), EnumSet.of(Modifier.PUBLIC),
                 typeStr, arg.getVariableName());
         writePutArguments(writer, arg.getVariableName(), "mArguments", arg);


### PR DESCRIPTION
Changes in FragmentBuilder:
```diff
@@ -25,6 +25,7 @@
     return new KotlinFragmentBuilder(a, andi, foo).build();
   }

+  @NonNull
   public KotlinFragmentBuilder bar(@Nullable String bar) {

     if (bar != null) {
@@ -33,6 +34,7 @@
     return this;
   }

+  @NonNull
   public KotlinFragmentBuilder model(@Nullable ParcelerModel model) {

     if (model != null) {
@@ -42,6 +44,7 @@
     return this;
   }

+  @NonNull
   public Bundle buildBundle() {
     return new Bundle(mArguments);
   }
```
