### PR TITLE
Allow protected fields

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -39,11 +39,18 @@
         <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
+            <version>0.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.truth0</groupId>
+            <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
+            <version>0.28</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.android</groupId>
+            <artifactId>android</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/AnnotatedFragment.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/AnnotatedFragment.java
@@ -37,6 +37,10 @@ public class AnnotatedFragment {
     this.classElement = classElement;
   }
 
+  public TypeElement getClassElement() {
+    return classElement;
+  }
+
   /**
    * Checks if a field (with the given name) is already in this class
    */

--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/AnnotatedFragment.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/AnnotatedFragment.java
@@ -205,7 +205,7 @@ public class AnnotatedFragment {
     }
 
     throw new ProcessingException(field.getElement(), "The @%s annotated field '%s' in class %s has " +
-        "private or protected visibility. Hence a corresponding setter method must be provided " +
+        "private visibility. Hence a corresponding non-private setter method must be provided " +
         "called '%s(%s)'. Unfortunately this is not the case. Please add a setter method for " +
         "this field!", Arg.class.getSimpleName(), field.getName(), getSimpleName(), methodName,
         field.getType());

--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgumentAnnotatedField.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgumentAnnotatedField.java
@@ -27,7 +27,7 @@ public class ArgumentAnnotatedField implements Comparable<ArgumentAnnotatedField
   private String bundlerClass;
   private String bundlerFieldName;
 
-  private boolean useSetterMethod = false;
+  private boolean useSetterMethod;
 
   public ArgumentAnnotatedField(Element element, TypeElement classElement, Arg annotation)
       throws ProcessingException {
@@ -39,10 +39,8 @@ public class ArgumentAnnotatedField implements Comparable<ArgumentAnnotatedField
     this.required = annotation.required();
     this.classElement = classElement;
 
-    // Private or protected fields need a setter method
-    useSetterMethod = element.getModifiers().contains(javax.lang.model.element.Modifier.PRIVATE)
-        || element.getModifiers().contains(javax.lang.model.element.Modifier.PROTECTED);
-
+    // Private fields need a setter method
+    useSetterMethod = element.getModifiers().contains(javax.lang.model.element.Modifier.PRIVATE);
 
     try {
       Class<? extends ArgsBundler> clazz = annotation.bundler();

--- a/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgumentAnnotatedField.java
+++ b/processor/src/main/java/com/hannesdorfmann/fragmentargs/processor/ArgumentAnnotatedField.java
@@ -27,8 +27,6 @@ public class ArgumentAnnotatedField implements Comparable<ArgumentAnnotatedField
   private String bundlerClass;
   private String bundlerFieldName;
 
-  private boolean useSetterMethod;
-
   public ArgumentAnnotatedField(Element element, TypeElement classElement, Arg annotation)
       throws ProcessingException {
 
@@ -38,9 +36,6 @@ public class ArgumentAnnotatedField implements Comparable<ArgumentAnnotatedField
     this.element = element;
     this.required = annotation.required();
     this.classElement = classElement;
-
-    // Private fields need a setter method
-    useSetterMethod = element.getModifiers().contains(javax.lang.model.element.Modifier.PRIVATE);
 
     try {
       Class<? extends ArgsBundler> clazz = annotation.bundler();
@@ -258,10 +253,6 @@ public class ArgumentAnnotatedField implements Comparable<ArgumentAnnotatedField
   @Override
   public int compareTo(ArgumentAnnotatedField o) {
     return getVariableName().compareTo(o.getVariableName());
-  }
-
-  public boolean isUseSetterMethod() {
-    return useSetterMethod;
   }
 
   public boolean isPrimitive() {

--- a/processor/src/test/java/com/hannesdorfmann/fragmentargs/processor/ProtectedAccessTest.java
+++ b/processor/src/test/java/com/hannesdorfmann/fragmentargs/processor/ProtectedAccessTest.java
@@ -1,0 +1,32 @@
+package com.hannesdorfmann.fragmentargs.processor;
+
+import com.google.testing.compile.JavaFileObjects;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assert_;
+import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
+
+public class ProtectedAccessTest {
+
+    private static final String[] PROCESSOR_OPTIONS
+            = new String[]{"-AfragmentArgsSupportAnnotations=false"};
+
+    @Test
+    public void protectedField() {
+        assert_().about(javaSource())
+                .that(JavaFileObjects.forResource("ClassWithProtectedField.java"))
+                .withCompilerOptions(PROCESSOR_OPTIONS)
+                .processedWith(new ArgProcessor())
+                .compilesWithoutError();
+    }
+
+    @Test
+    public void protectedSetter() {
+        assert_().about(javaSource())
+                .that(JavaFileObjects.forResource("ClassWithProtectedSetter.java"))
+                .withCompilerOptions(PROCESSOR_OPTIONS)
+                .processedWith(new ArgProcessor())
+                .compilesWithoutError();
+    }
+}

--- a/processor/src/test/resources/ClassWithProtectedField.java
+++ b/processor/src/test/resources/ClassWithProtectedField.java
@@ -1,0 +1,7 @@
+package com.hannesdorfmann.fragmentargs.processor.test;
+
+@com.hannesdorfmann.fragmentargs.annotation.FragmentWithArgs
+public class ClassWithProtectedField extends android.app.Fragment {
+    @com.hannesdorfmann.fragmentargs.annotation.Arg
+    protected String protectedArg;
+}

--- a/processor/src/test/resources/ClassWithProtectedSetter.java
+++ b/processor/src/test/resources/ClassWithProtectedSetter.java
@@ -1,0 +1,11 @@
+package com.hannesdorfmann.fragmentargs.processor.test;
+
+@com.hannesdorfmann.fragmentargs.annotation.FragmentWithArgs
+public class ClassWithProtectedSetter extends android.app.Fragment {
+    @com.hannesdorfmann.fragmentargs.annotation.Arg
+    private String privateArg;
+
+    protected void setPrivateArg(String privateArg) {
+        this.privateArg = privateArg;
+    }
+}


### PR DESCRIPTION
This fixes #61 

Force setter usage only for **private** and **non-public** fields from a different package.