### PR TITLE
allow jdk8 to be used for snapshot deployment

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -6,7 +6,7 @@
 # http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 SLUG="sockeqwe/fragmentargs"
-JDK="oraclejdk7"
+JDK="oraclejdk8"
 BRANCH="master"
 
 set -e


### PR DESCRIPTION
If you take a look at the following travis build you can see why the snapshot deployment was skipped:
https://travis-ci.org/sockeqwe/fragmentargs/builds/394610516#L2514

```
Skipping snapshot deployment: wrong JDK. Expected 'oraclejdk7' but was 'oraclejdk8'.
```